### PR TITLE
CSP-363 - /Region endpoint

### DIFF
--- a/postman-tests/SFA.DAS.AAN.Hub.Api-devenv.json
+++ b/postman-tests/SFA.DAS.AAN.Hub.Api-devenv.json
@@ -1,0 +1,1 @@
+{"id":"d10f28e4-d5d1-4f46-9b89-f57ef700d9c6","name":"SFA.DAS.AAN.Hub.Api - Local dev","values":[{"key":"api-base-url","value":"https://localhost:7299","enabled":true,"type":"default"}]}

--- a/postman-tests/SFA.DAS.AAN.Hub.Api.postman_collection.json
+++ b/postman-tests/SFA.DAS.AAN.Hub.Api.postman_collection.json
@@ -1,0 +1,32 @@
+{
+	"info": {
+		"_postman_id": "54742dbe-484c-42df-a51a-2d16bdfe4d17",
+		"name": "SFA.DAS.AAN.Hub.Api",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "5594608"
+	},
+	"item": [
+		{
+			"name": "Region",
+			"item": []
+		},
+		{
+			"name": "GetAllRegions",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{api-base-url}}/api/region",
+					"host": [
+						"{{api-base-url}}"
+					],
+					"path": [
+						"api",
+						"region"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/src/SFA.DAS.AAN.Application.UnitTests/AutofixtureExtensions.cs
+++ b/src/SFA.DAS.AAN.Application.UnitTests/AutofixtureExtensions.cs
@@ -1,0 +1,95 @@
+﻿using AutoFixture;
+using AutoFixture.AutoMoq;
+using AutoFixture.Kernel;
+using AutoFixture.Xunit2;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using SFA.DAS.AAN.Data;
+using SFA.DAS.AAN.Domain.Interfaces;
+
+namespace SFA.DAS.AAN.Application.UnitTests
+{
+    public static class AutofixtureExtensions
+    {
+        public static IFixture AanFixture()
+        {
+            var fixture = new Fixture();
+            fixture.Behaviors.Remove(new ThrowingRecursionBehavior());
+            fixture.Behaviors.Add(new OmitOnRecursionBehavior());
+            fixture.Customize(new ApprenticeFeedbackCustomization());
+            fixture.Customize(new AutoMoqCustomization { ConfigureMembers = true });
+            return fixture;
+        }
+    }
+
+    public class AutoMoqDataAttribute : AutoDataAttribute
+    {
+        public AutoMoqDataAttribute()
+            : base(AutofixtureExtensions.AanFixture)
+        {
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    public class AutoMoqInlineAutoDataAttribute : InlineAutoDataAttribute
+    {
+        public AutoMoqInlineAutoDataAttribute(params object[] arguments)
+            : base(AutofixtureExtensions.AanFixture(), arguments)
+        {
+        }
+    }
+
+    public class ApprenticeFeedbackCustomization : ICustomization
+    {
+        public void Customize(IFixture fixture)
+        {
+            if (fixture == null)
+            {
+                throw new ArgumentNullException("fixture");
+            }
+
+            fixture.Customizations.Add(new AANDataContextBuilder());
+            fixture.Customizations.Add(new DateTimeHelperBuilder());
+        }
+    }
+
+    public class AANDataContextBuilder : ISpecimenBuilder
+    {
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (request is Type type && type == typeof(AanDataContext))
+            {
+
+                var connection = new SqliteConnection("Filename=:memory:");
+                connection.Open();
+
+                // These options will be used by the context instances in this test suite, including the connection opened above.
+                var contextOptions = new DbContextOptionsBuilder<AanDataContext>()
+                    .UseSqlite(connection)
+                    .Options;
+
+                // Create the schema and seed some data
+                var dbContext = new AanDataContext(contextOptions);
+                dbContext.Database.EnsureCreated();
+
+                return dbContext;
+            }
+
+            return new NoSpecimen();
+        }
+    }
+
+    // Handy for unit testing - make sure any IDateTimeHelper instances are "now"
+    public class DateTimeHelperBuilder : ISpecimenBuilder
+    {
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (request is Type type && type == typeof(IDateTimeHelper))
+            {
+                return new UtcTimeProvider();
+            }
+
+            return new NoSpecimen();
+        }
+    }
+}

--- a/src/SFA.DAS.AAN.Application.UnitTests/Queries/WhenRequestingGetAllRegions.cs
+++ b/src/SFA.DAS.AAN.Application.UnitTests/Queries/WhenRequestingGetAllRegions.cs
@@ -1,0 +1,27 @@
+﻿using AutoFixture.Xunit2;
+using FluentAssertions;
+using SFA.DAS.AAN.Application.Queries.GetAllRegions;
+using SFA.DAS.AAN.Data;
+using SFA.DAS.AAN.Domain.Entities;
+
+namespace SFA.DAS.AAN.Application.UnitTests.Queries
+{
+    public class WhenRequestingGetAllRegions
+    {
+        [Theory, AutoMoqData]
+        public async Task ThenAllRegionsAreReturned(
+            GetAllRegionsQuery query,
+            [Frozen(Matching.ImplementedInterfaces)] AanDataContext context,
+            GetAllRegionsQueryHandler handler,
+            List<Region> response)
+        {
+
+            context.Regions.AddRange(response);
+            context.SaveChanges();
+
+            var result = await handler.Handle(query, CancellationToken.None);
+
+            result?.Regions?.Count.Should().Be(response.Count);
+        }
+    }
+}

--- a/src/SFA.DAS.AAN.Application.UnitTests/SFA.DAS.AAN.Application.UnitTests.csproj
+++ b/src/SFA.DAS.AAN.Application.UnitTests/SFA.DAS.AAN.Application.UnitTests.csproj
@@ -1,0 +1,41 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
+    <PackageReference Include="FluentAssertions" Version="6.8.0" />
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="6.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Commands\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SFA.DAS.AAN.Application\SFA.DAS.AAN.Application.csproj" />
+    <ProjectReference Include="..\SFA.DAS.AAN.Data\SFA.DAS.AAN.Data.csproj" />
+    <ProjectReference Include="..\SFA.DAS.AAN.Domain\SFA.DAS.AAN.Domain.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/SFA.DAS.AAN.Application.UnitTests/Usings.cs
+++ b/src/SFA.DAS.AAN.Application.UnitTests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/src/SFA.DAS.AAN.Application/Commands/CreateMemberCommand.cs
+++ b/src/SFA.DAS.AAN.Application/Commands/CreateMemberCommand.cs
@@ -1,0 +1,8 @@
+﻿using MediatR;
+
+namespace SFA.DAS.AAN.Application.Commands
+{
+    public class CreateMemberCommand : IRequest
+    {
+    }
+}

--- a/src/SFA.DAS.AAN.Application/Queries/GetAllRegions/GetAllRegionsQuery.cs
+++ b/src/SFA.DAS.AAN.Application/Queries/GetAllRegions/GetAllRegionsQuery.cs
@@ -1,0 +1,8 @@
+﻿using MediatR;
+
+namespace SFA.DAS.AAN.Application.Queries.GetAllRegions
+{
+    public class GetAllRegionsQuery : IRequest<GetAllRegionsResult>
+    {
+    }
+}

--- a/src/SFA.DAS.AAN.Application/Queries/GetAllRegions/GetAllRegionsQueryHandler.cs
+++ b/src/SFA.DAS.AAN.Application/Queries/GetAllRegions/GetAllRegionsQueryHandler.cs
@@ -7,16 +7,16 @@ namespace SFA.DAS.AAN.Application.Queries.GetAllRegions
 {
     public class GetAllRegionsQueryHandler : IRequestHandler<GetAllRegionsQuery, GetAllRegionsResult>
     {
-        private readonly IMembersContext _membersContext;
+        private readonly IRegionsContext _regionsContext;
 
-        public GetAllRegionsQueryHandler(IMembersContext membersContext)
+        public GetAllRegionsQueryHandler(IRegionsContext regionsContext)
         {
-            _membersContext = membersContext;
+            _regionsContext = regionsContext;
         }
 
         public async Task<GetAllRegionsResult> Handle(GetAllRegionsQuery request, CancellationToken cancellationToken)
         {
-            var regionSummary = await _membersContext.Entities.ToListAsync(cancellationToken);
+            var regionSummary = await _regionsContext.Entities.ToListAsync(cancellationToken);
 
             return regionSummary.Any()
                 ? new GetAllRegionsResult

--- a/src/SFA.DAS.AAN.Application/Queries/GetAllRegions/GetAllRegionsQueryHandler.cs
+++ b/src/SFA.DAS.AAN.Application/Queries/GetAllRegions/GetAllRegionsQueryHandler.cs
@@ -1,0 +1,30 @@
+﻿using MediatR;
+using Microsoft.EntityFrameworkCore;
+using SFA.DAS.AAN.Domain.Entities;
+using SFA.DAS.AAN.Domain.Interfaces;
+
+namespace SFA.DAS.AAN.Application.Queries.GetAllRegions
+{
+    public class GetAllRegionsQueryHandler : IRequestHandler<GetAllRegionsQuery, GetAllRegionsResult>
+    {
+        private readonly IMembersContext _membersContext;
+
+        public GetAllRegionsQueryHandler(IMembersContext membersContext)
+        {
+            _membersContext = membersContext;
+        }
+
+        public async Task<GetAllRegionsResult> Handle(GetAllRegionsQuery request, CancellationToken cancellationToken)
+        {
+            var regionSummary = await _membersContext.Entities.ToListAsync(cancellationToken);
+
+            return regionSummary.Any()
+                ? new GetAllRegionsResult
+                {
+                    Regions = regionSummary
+                }
+                : new GetAllRegionsResult { Regions = new List<Region>() };
+
+        }
+    }
+}

--- a/src/SFA.DAS.AAN.Application/Queries/GetAllRegions/GetAllRegionsResult.cs
+++ b/src/SFA.DAS.AAN.Application/Queries/GetAllRegions/GetAllRegionsResult.cs
@@ -1,0 +1,9 @@
+﻿using SFA.DAS.AAN.Domain.Entities;
+
+namespace SFA.DAS.AAN.Application.Queries.GetAllRegions
+{
+    public class GetAllRegionsResult
+    {
+        public ICollection<Region>? Regions { get; set; }
+    }
+}

--- a/src/SFA.DAS.AAN.Application/SFA.DAS.AAN.Application.csproj
+++ b/src/SFA.DAS.AAN.Application/SFA.DAS.AAN.Application.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.10" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SFA.DAS.AAN.Domain\SFA.DAS.AAN.Domain.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/SFA.DAS.AAN.Data/AANDataContext.cs
+++ b/src/SFA.DAS.AAN.Data/AANDataContext.cs
@@ -1,0 +1,100 @@
+﻿using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using SFA.DAS.AAN.Data.Configuration;
+using SFA.DAS.AAN.Domain.Configuration;
+using SFA.DAS.AAN.Domain.Entities;
+using SFA.DAS.AAN.Domain.Interfaces;
+
+namespace SFA.DAS.AAN.Data
+{
+    public class AanDataContext : DbContext,
+        IMembersContext
+    {
+        private readonly ApplicationSettings? _configuration;
+
+        public virtual DbSet<Region> Regions { get; set; } = null!;
+
+        DbSet<Region> IEntityContext<Region>.Entities => Regions;
+
+        public AanDataContext(DbContextOptions<AanDataContext> options) : base(options)
+        {
+        }
+
+        public AanDataContext(IOptions<ApplicationSettings> config, DbContextOptions<AanDataContext> options) : base(options)
+        {
+            _configuration = config.Value;
+        }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            if (_configuration == null)
+            {
+                return;
+            }
+
+            var connection = new SqlConnection
+            {
+                ConnectionString = _configuration.DbConnectionString
+            };
+
+            optionsBuilder.UseSqlServer(connection);
+
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.ApplyConfiguration(new RegionConfiguration());
+            base.OnModelCreating(modelBuilder);
+        }
+
+        public override int SaveChanges(bool acceptAllChangesOnSuccess)
+        {
+            OnBeforeSaving();
+            return base.SaveChanges(acceptAllChangesOnSuccess);
+        }
+
+        public override async Task<int> SaveChangesAsync(
+            bool acceptAllChangesOnSuccess,
+            CancellationToken cancellationToken = default
+        )
+        {
+            OnBeforeSaving();
+            return await base.SaveChangesAsync(acceptAllChangesOnSuccess,
+                cancellationToken);
+        }
+
+        private void OnBeforeSaving()
+        {
+            var entries = ChangeTracker.Entries();
+            var utcNow = DateTime.UtcNow;
+
+            foreach (var entry in entries)
+            {
+                // for entities that inherit from BaseEntity,
+                // set UpdatedOn / CreatedOn appropriately
+                if (entry.Entity is EntityBase trackable)
+                {
+                    switch (entry.State)
+                    {
+                        case EntityState.Modified:
+                            // set the updated date to "now"
+                            trackable.UpdatedOn = utcNow;
+
+                            // mark property as "don't touch"
+                            // we don't want to update on a Modify operation
+                            entry.Property("CreatedOn").IsModified = false;
+                            break;
+
+                        case EntityState.Added:
+                            // set both updated and created date to "now"
+                            trackable.CreatedOn = utcNow;
+                            trackable.UpdatedOn = utcNow;
+                            break;
+                    }
+
+                }
+            }
+        }
+    }
+}

--- a/src/SFA.DAS.AAN.Data/AANDataContext.cs
+++ b/src/SFA.DAS.AAN.Data/AANDataContext.cs
@@ -9,7 +9,7 @@ using SFA.DAS.AAN.Domain.Interfaces;
 namespace SFA.DAS.AAN.Data
 {
     public class AanDataContext : DbContext,
-        IMembersContext
+        IRegionsContext
     {
         private readonly ApplicationSettings? _configuration;
 

--- a/src/SFA.DAS.AAN.Data/Configuration/RegionConfiguration.cs
+++ b/src/SFA.DAS.AAN.Data/Configuration/RegionConfiguration.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using SFA.DAS.AAN.Domain.Entities;
+
+namespace SFA.DAS.AAN.Data.Configuration
+{
+    public class RegionConfiguration : IEntityTypeConfiguration<Region>
+    {
+        public void Configure(EntityTypeBuilder<Region> builder)
+        {
+            builder.ToTable("Region");
+            builder.HasKey(x => x.Id);
+        }
+    }
+}

--- a/src/SFA.DAS.AAN.Data/SFA.DAS.AAN.Data.csproj
+++ b/src/SFA.DAS.AAN.Data/SFA.DAS.AAN.Data.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.10" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SFA.DAS.AAN.Domain\SFA.DAS.AAN.Domain.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/SFA.DAS.AAN.Domain/Configuration/ApplicationSettings.cs
+++ b/src/SFA.DAS.AAN.Domain/Configuration/ApplicationSettings.cs
@@ -1,0 +1,7 @@
+﻿namespace SFA.DAS.AAN.Domain.Configuration
+{
+    public class ApplicationSettings
+    {
+        public string? DbConnectionString { get; set; }
+    }
+}

--- a/src/SFA.DAS.AAN.Domain/Entities/EntityBase.cs
+++ b/src/SFA.DAS.AAN.Domain/Entities/EntityBase.cs
@@ -1,0 +1,8 @@
+﻿namespace SFA.DAS.AAN.Domain.Entities
+{
+    public class EntityBase
+    {
+        public DateTime CreatedOn { get; set; }
+        public DateTime UpdatedOn { get; set; }
+    }
+}

--- a/src/SFA.DAS.AAN.Domain/Entities/Region.cs
+++ b/src/SFA.DAS.AAN.Domain/Entities/Region.cs
@@ -1,0 +1,9 @@
+﻿namespace SFA.DAS.AAN.Domain.Entities
+{
+    public class Region
+    {
+        public int Id { get; set; }
+        public string Area { get; set; }
+        public int Ordering { get; set; }
+    }
+}

--- a/src/SFA.DAS.AAN.Domain/Interfaces/IDateTimeHelper.cs
+++ b/src/SFA.DAS.AAN.Domain/Interfaces/IDateTimeHelper.cs
@@ -1,0 +1,27 @@
+﻿namespace SFA.DAS.AAN.Domain.Interfaces
+{
+    public interface IDateTimeHelper
+    {
+        DateTime Now { get; }
+    }
+
+    public class UtcTimeProvider : IDateTimeHelper
+    {
+        public DateTime Now => DateTime.UtcNow;
+    }
+
+    public class SpecifiedTimeProvider : IDateTimeHelper
+    {
+        public DateTime Now { get; set; }
+
+        public SpecifiedTimeProvider(DateTime time)
+        {
+            Now = time;
+        }
+
+        public void Advance(TimeSpan timeSpan)
+        {
+            Now = Now.Add(timeSpan);
+        }
+    }
+}

--- a/src/SFA.DAS.AAN.Domain/Interfaces/IEntityContext.cs
+++ b/src/SFA.DAS.AAN.Domain/Interfaces/IEntityContext.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace SFA.DAS.AAN.Domain.Interfaces
+{
+    public interface IEntityContext<T> where T : class
+    {
+        DbSet<T> Entities { get; }
+    }
+}

--- a/src/SFA.DAS.AAN.Domain/Interfaces/IMembersContext.cs
+++ b/src/SFA.DAS.AAN.Domain/Interfaces/IMembersContext.cs
@@ -1,0 +1,8 @@
+﻿using SFA.DAS.AAN.Domain.Entities;
+
+namespace SFA.DAS.AAN.Domain.Interfaces
+{
+    public interface IMembersContext : IEntityContext<Region>
+    {
+    }
+}

--- a/src/SFA.DAS.AAN.Domain/Interfaces/IRegionsContext.cs
+++ b/src/SFA.DAS.AAN.Domain/Interfaces/IRegionsContext.cs
@@ -2,7 +2,7 @@
 
 namespace SFA.DAS.AAN.Domain.Interfaces
 {
-    public interface IMembersContext : IEntityContext<Region>
+    public interface IRegionsContext : IEntityContext<Region>
     {
     }
 }

--- a/src/SFA.DAS.AAN.Domain/SFA.DAS.AAN.Domain.csproj
+++ b/src/SFA.DAS.AAN.Domain/SFA.DAS.AAN.Domain.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.10">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/src/SFA.DAS.AAN.Hub.Api.UnitTests/Members/WhenRequestRegions.cs
+++ b/src/SFA.DAS.AAN.Hub.Api.UnitTests/Members/WhenRequestRegions.cs
@@ -1,0 +1,37 @@
+﻿using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using SFA.DAS.AAN.Application.Queries.GetAllRegions;
+using SFA.DAS.AAN.Hub.Api.Controllers;
+
+namespace SFA.DAS.AAN.Hub.Api.UnitTests.Members
+{
+    public class WhenRequestRegions
+    {
+        private readonly Mock<IMediator> _mediator;
+        private readonly Mock<ILogger<RegionController>> _logger;
+
+        public WhenRequestRegions()
+        {
+            _mediator = new Mock<IMediator>();
+            _logger = new Mock<ILogger<RegionController>>();
+        }
+
+        [Fact]
+        public async Task And_MediatorCommandSuccessful_Then_ReturnOk()
+        {
+            var response = new GetAllRegionsResult();
+            _mediator.Setup(m => m.Send(It.IsAny<GetAllRegionsResult>(), It.IsAny<CancellationToken>())).ReturnsAsync(response);
+            var controller = new RegionController(_mediator.Object, _logger.Object);
+
+            var result = await controller.GetListOfRegions() as OkObjectResult;
+
+            result.Should().NotBeNull();
+            var model = result?.Value;
+            model.Should().BeEquivalentTo(response.Regions);
+
+        }
+    }
+}

--- a/src/SFA.DAS.AAN.Hub.Api.UnitTests/SFA.DAS.AAN.Hub.Api.UnitTests.csproj
+++ b/src/SFA.DAS.AAN.Hub.Api.UnitTests/SFA.DAS.AAN.Hub.Api.UnitTests.csproj
@@ -1,0 +1,38 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AutoFixture" Version="4.17.0" />
+    <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
+    <PackageReference Include="FluentAssertions" Version="6.8.0" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="6.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SFA.DAS.AAN.Application\SFA.DAS.AAN.Application.csproj" />
+    <ProjectReference Include="..\SFA.DAS.AAN.Hub.Api\SFA.DAS.AAN.Hub.Api.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/SFA.DAS.AAN.Hub.Api.UnitTests/Usings.cs
+++ b/src/SFA.DAS.AAN.Hub.Api.UnitTests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/src/SFA.DAS.AAN.Hub.Api.sln
+++ b/src/SFA.DAS.AAN.Hub.Api.sln
@@ -4,8 +4,23 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 17.3.32929.385
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SFA.DAS.AAN.Hub.Api", "SFA.DAS.AAN.Hub.Api\SFA.DAS.AAN.Hub.Api.csproj", "{5D99EED1-8485-4449-AADF-70983163543E}"
+	ProjectSection(ProjectDependencies) = postProject
+		{5A0940AB-5684-4FA5-B018-06A7FC0ED0A4} = {5A0940AB-5684-4FA5-B018-06A7FC0ED0A4}
+	EndProjectSection
 EndProject
 Project("{00D1A9C2-B5F0-4AF3-8072-F6C62B433612}") = "SFA.DAS.AAN.Hub.Database", "SFA.DAS.AAN.Hub.Database\SFA.DAS.AAN.Hub.Database.sqlproj", "{30ADF3A6-0B05-4C38-AA10-AC911E3DEA6F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SFA.DAS.AAN.Domain", "SFA.DAS.AAN.Domain\SFA.DAS.AAN.Domain.csproj", "{5A0940AB-5684-4FA5-B018-06A7FC0ED0A4}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SFA.DAS.AAN.Application", "SFA.DAS.AAN.Application\SFA.DAS.AAN.Application.csproj", "{F87B8944-977A-4C15-932C-D898F6522F86}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SFA.DAS.AAN.Data", "SFA.DAS.AAN.Data\SFA.DAS.AAN.Data.csproj", "{A803A41A-9E42-4805-AA0D-EC0B2F315F44}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{9C02B1F9-3515-42AE-A8CE-661597E7C488}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SFA.DAS.AAN.Hub.Api.UnitTests", "SFA.DAS.AAN.Hub.Api.UnitTests\SFA.DAS.AAN.Hub.Api.UnitTests.csproj", "{6CD2805C-B468-4287-9D65-2E5AD771E412}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SFA.DAS.AAN.Application.UnitTests", "SFA.DAS.AAN.Application.UnitTests\SFA.DAS.AAN.Application.UnitTests.csproj", "{6A74BAA5-FD22-4EA0-B0AD-397795A109C6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -23,9 +38,33 @@ Global
 		{30ADF3A6-0B05-4C38-AA10-AC911E3DEA6F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{30ADF3A6-0B05-4C38-AA10-AC911E3DEA6F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{30ADF3A6-0B05-4C38-AA10-AC911E3DEA6F}.Release|Any CPU.Deploy.0 = Release|Any CPU
+		{5A0940AB-5684-4FA5-B018-06A7FC0ED0A4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A0940AB-5684-4FA5-B018-06A7FC0ED0A4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5A0940AB-5684-4FA5-B018-06A7FC0ED0A4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5A0940AB-5684-4FA5-B018-06A7FC0ED0A4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F87B8944-977A-4C15-932C-D898F6522F86}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F87B8944-977A-4C15-932C-D898F6522F86}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F87B8944-977A-4C15-932C-D898F6522F86}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F87B8944-977A-4C15-932C-D898F6522F86}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A803A41A-9E42-4805-AA0D-EC0B2F315F44}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A803A41A-9E42-4805-AA0D-EC0B2F315F44}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A803A41A-9E42-4805-AA0D-EC0B2F315F44}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A803A41A-9E42-4805-AA0D-EC0B2F315F44}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6CD2805C-B468-4287-9D65-2E5AD771E412}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6CD2805C-B468-4287-9D65-2E5AD771E412}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6CD2805C-B468-4287-9D65-2E5AD771E412}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6CD2805C-B468-4287-9D65-2E5AD771E412}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6A74BAA5-FD22-4EA0-B0AD-397795A109C6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A74BAA5-FD22-4EA0-B0AD-397795A109C6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A74BAA5-FD22-4EA0-B0AD-397795A109C6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6A74BAA5-FD22-4EA0-B0AD-397795A109C6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{6CD2805C-B468-4287-9D65-2E5AD771E412} = {9C02B1F9-3515-42AE-A8CE-661597E7C488}
+		{6A74BAA5-FD22-4EA0-B0AD-397795A109C6} = {9C02B1F9-3515-42AE-A8CE-661597E7C488}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3EE5F86F-9329-412E-93CB-C1E461DC822A}

--- a/src/SFA.DAS.AAN.Hub.Api/AppStart/AddDatabaseRegistrations.cs
+++ b/src/SFA.DAS.AAN.Hub.Api/AppStart/AddDatabaseRegistrations.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.EntityFrameworkCore;
+using SFA.DAS.AAN.Data;
+using SFA.DAS.AAN.Domain.Configuration;
+
+namespace SFA.DAS.AAN.Hub.Api.AppStart
+{
+    public static class AddDatabaseRegistrations
+    {
+        public static void AddDatabaseRegistration(this IServiceCollection services, IConfiguration configuration)
+        {
+            var appSettings = configuration.GetSection("ApplicationSettings").Get<ApplicationSettings>();
+
+            services.AddDbContext<AanDataContext>(
+                options => options.UseSqlServer(appSettings.DbConnectionString).EnableSensitiveDataLogging(),
+                ServiceLifetime.Transient);
+
+
+        }
+    }
+}

--- a/src/SFA.DAS.AAN.Hub.Api/AppStart/AddServiceRegistration.cs
+++ b/src/SFA.DAS.AAN.Hub.Api/AppStart/AddServiceRegistration.cs
@@ -10,7 +10,7 @@ namespace SFA.DAS.AAN.Hub.Api.AppStart
         public static void AddServices(this IServiceCollection services)
         {
             services.AddMediatR(typeof(CreateMemberCommand).Assembly);
-            services.AddScoped<IMembersContext>(s => s.GetRequiredService<AanDataContext>());
+            services.AddScoped<IRegionsContext>(s => s.GetRequiredService<AanDataContext>());
         }
     }
 }

--- a/src/SFA.DAS.AAN.Hub.Api/AppStart/AddServiceRegistration.cs
+++ b/src/SFA.DAS.AAN.Hub.Api/AppStart/AddServiceRegistration.cs
@@ -1,0 +1,16 @@
+﻿using MediatR;
+using SFA.DAS.AAN.Application.Commands;
+using SFA.DAS.AAN.Data;
+using SFA.DAS.AAN.Domain.Interfaces;
+
+namespace SFA.DAS.AAN.Hub.Api.AppStart
+{
+    public static class AddServiceRegistration
+    {
+        public static void AddServices(this IServiceCollection services)
+        {
+            services.AddMediatR(typeof(CreateMemberCommand).Assembly);
+            services.AddScoped<IMembersContext>(s => s.GetRequiredService<AanDataContext>());
+        }
+    }
+}

--- a/src/SFA.DAS.AAN.Hub.Api/AppStart/ConfigurationExtensions.cs
+++ b/src/SFA.DAS.AAN.Hub.Api/AppStart/ConfigurationExtensions.cs
@@ -1,0 +1,17 @@
+﻿namespace SFA.DAS.AAN.Hub.Api.AppStart
+{
+    public static class ConfigurationExtensions
+    {
+        public static bool IsLocalAcceptanceOrDev(this IConfiguration config)
+        {
+            return config["EnvironmentName"].Equals("LOCAL", StringComparison.CurrentCultureIgnoreCase) ||
+                   config["EnvironmentName"].Equals("ACCEPTANCE_TESTS", StringComparison.CurrentCultureIgnoreCase) ||
+                   config["EnvironmentName"].Equals("DEV", StringComparison.CurrentCultureIgnoreCase);
+        }
+
+        public static bool IsIntegrationTests(this IConfiguration config)
+        {
+            return config["EnvironmentName"].Equals("IntegrationTests", StringComparison.CurrentCultureIgnoreCase);
+        }
+    }
+}

--- a/src/SFA.DAS.AAN.Hub.Api/Controllers/RegionController.cs
+++ b/src/SFA.DAS.AAN.Hub.Api/Controllers/RegionController.cs
@@ -1,0 +1,34 @@
+﻿using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using SFA.DAS.AAN.Application.Queries.GetAllRegions;
+
+namespace SFA.DAS.AAN.Hub.Api.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]/")]
+    public class RegionController : Controller
+    {
+        private readonly IMediator _mediator;
+        private readonly ILogger<RegionController> _logger;
+
+        public RegionController(IMediator mediator, ILogger<RegionController> logger)
+        {
+            _mediator = mediator;
+            _logger = logger;
+        }
+        [HttpGet]
+        public async Task<IActionResult> GetListOfRegions()
+        {
+            try
+            {
+                var result = await _mediator.Send(new GetAllRegionsQuery());
+                return Ok(result);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, $"Error attempting to retrieve list of regions");
+                return BadRequest();
+            }
+        }
+    }
+}

--- a/src/SFA.DAS.AAN.Hub.Api/SFA.DAS.AAN.Hub.Api.csproj
+++ b/src/SFA.DAS.AAN.Hub.Api/SFA.DAS.AAN.Hub.Api.csproj
@@ -11,13 +11,22 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.10">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.10" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="5.1.5" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Controllers\" />
+    <ProjectReference Include="..\SFA.DAS.AAN.Application\SFA.DAS.AAN.Application.csproj" />
+    <ProjectReference Include="..\SFA.DAS.AAN.Data\SFA.DAS.AAN.Data.csproj" />
+    <ProjectReference Include="..\SFA.DAS.AAN.Domain\SFA.DAS.AAN.Domain.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/SFA.DAS.AAN.Hub.Api/Startup.cs
+++ b/src/SFA.DAS.AAN.Hub.Api/Startup.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.OpenApi.Models;
+﻿using Microsoft.Extensions.Options;
+using Microsoft.OpenApi.Models;
+using SFA.DAS.AAN.Domain.Configuration;
+using SFA.DAS.AAN.Hub.Api.AppStart;
 
 namespace SFA.DAS.AAN.Hub.Api
 {
@@ -28,6 +31,12 @@ namespace SFA.DAS.AAN.Hub.Api
             {
                 c.SwaggerDoc("v1", new OpenApiInfo { Title = "SFA.DAS.AAN.Hub.Api", Version = "v1" });
             });
+            services.Configure<ApplicationSettings>(Configuration.GetSection("ApplicationSettings"));
+            services.AddSingleton(s => s.GetRequiredService<IOptions<ApplicationSettings>>().Value);
+
+            services.AddDatabaseRegistration(Configuration);
+            services.AddControllers();
+            services.AddServices();
 
         }
 
@@ -43,6 +52,12 @@ namespace SFA.DAS.AAN.Hub.Api
             app.UseHttpsRedirection();
 
             app.UseRouting();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+                //endpoints.MapHealthChecks("/ping");
+            });
         }
     }
 }

--- a/src/SFA.DAS.AAN.Hub.Api/appsettings.Development.json
+++ b/src/SFA.DAS.AAN.Hub.Api/appsettings.Development.json
@@ -2,7 +2,17 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
     }
+  },
+  "AllowedHosts": "*",
+  "ConfigurationStorageConnectionString": "UseDevelopmentStorage=true",
+  "ConfigNames": "SFA.DAS.AAN.Hub.Api",
+  "EnvironmentName": "LOCAL",
+  "Version": "1.0",
+
+  "ApplicationSettings": {
+    "DbConnectionString": "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=SFA.DAS.AAN.Hub.Database;Integrated Security=True;Connect Timeout=60;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False"
   }
 }

--- a/src/SFA.DAS.AAN.Hub.Api/appsettings.json
+++ b/src/SFA.DAS.AAN.Hub.Api/appsettings.json
@@ -2,8 +2,17 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ConfigurationStorageConnectionString": "UseDevelopmentStorage=true",
+  "ConfigNames": "SFA.DAS.AAN.Hub.Api",
+  "EnvironmentName": "LOCAL",
+  "Version": "1.0",
+
+  "ApplicationSettings": {
+    "DbConnectionString": "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=SFA.DAS.AAN.Hub.Database;Integrated Security=True;Connect Timeout=60;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False"
+  }
 }


### PR DESCRIPTION
/Region endpoint (GetAllRegions) implemented, as well as various middleware tasks for generic API development and unit testing.

Example output: 
```
{
    "regions": [
        {
            "id": 1,
            "area": "East Midlands",
            "ordering": 1
        },
        {
            "id": 2,
            "area": "East of England",
            "ordering": 2
        },
        {
            "id": 3,
            "area": "London",
            "ordering": 3
        },
        {
            "id": 4,
            "area": "North East",
            "ordering": 4
        },
        {
            "id": 5,
            "area": "North West",
            "ordering": 5
        },
        {
            "id": 6,
            "area": "South East",
            "ordering": 6
        },
        {
            "id": 7,
            "area": "South West",
            "ordering": 7
        },
        {
            "id": 8,
            "area": "West Midlands",
            "ordering": 8
        },
        {
            "id": 9,
            "area": "Yorkshire and the Humber",
            "ordering": 9
        }
    ]
}
```