### PR TITLE
CSP-467 - Fixed null request properties

### DIFF
--- a/src/SFA.DAS.AANHub.Api.UnitTests/Controllers/EmployersControllerTests.cs
+++ b/src/SFA.DAS.AANHub.Api.UnitTests/Controllers/EmployersControllerTests.cs
@@ -26,6 +26,7 @@ namespace SFA.DAS.AANHub.Api.UnitTests.Controllers
                 Status = MembershipStatus.Live.ToString(),
             };
 
+            model.Regions = new List<int>(new[] { 1, 2, });
             mediatorMock.Setup(m => m.Send(It.Is<CreateEmployerMemberCommand>(c => c.UserId == userId && c.Organisation == organisation && c.AccountId == accountId), It.IsAny<CancellationToken>())).ReturnsAsync(response);
             var result = await sut.CreateEmployer(Guid.NewGuid(), model);
 

--- a/src/SFA.DAS.AANHub.Api.UnitTests/Controllers/EmployersControllerTests.cs
+++ b/src/SFA.DAS.AANHub.Api.UnitTests/Controllers/EmployersControllerTests.cs
@@ -29,7 +29,7 @@ namespace SFA.DAS.AANHub.Api.UnitTests.Controllers
             mediatorMock.Setup(m => m.Send(It.Is<CreateEmployerMemberCommand>(c => c.UserId == userId && c.Organisation == organisation && c.AccountId == accountId), It.IsAny<CancellationToken>())).ReturnsAsync(response);
             var result = await sut.CreateEmployer(Guid.NewGuid(), model);
 
-            result.As<CreatedAtActionResult>().ControllerName.Should().Be("Employer");
+            result.As<CreatedAtActionResult>().ControllerName.Should().Be("Employers");
             result.As<CreatedAtActionResult>().ActionName.Should().Be("CreateEmployer");
             result.As<CreatedAtActionResult>().StatusCode.Should().Be(201);
         }

--- a/src/SFA.DAS.AANHub.Api/Controllers/EmployersController.cs
+++ b/src/SFA.DAS.AANHub.Api/Controllers/EmployersController.cs
@@ -36,7 +36,7 @@ namespace SFA.DAS.AANHub.Api.Controllers
             command.RequestedByUserId = userId;
 
             var response = await _mediator.Send(command);
-            return new CreatedAtActionResult(nameof(CreateEmployer), "Employer", new { id = response.MemberId }, response);
+            return new CreatedAtActionResult(nameof(CreateEmployer), "Employers", new { id = response.MemberId }, response);
         }
     }
 }

--- a/src/SFA.DAS.AANHub.Api/Models/CreateEmployerModel.cs
+++ b/src/SFA.DAS.AANHub.Api/Models/CreateEmployerModel.cs
@@ -8,7 +8,7 @@ namespace SFA.DAS.AANHub.Api.Models
         public long UserId { get; set; }
         public string? Organisation { get; set; }
         public DateTime Joined { get; set; }
-        public int? Region { get; set; }
+        public int[]? Regions { get; set; }
         public string? Information { get; set; }
         public string Email { get; set; } = null!;
         public string Name { get; set; } = null!;
@@ -20,6 +20,10 @@ namespace SFA.DAS.AANHub.Api.Models
             Organisation = model.Organisation,
             Email = model.Email,
             Name = model.Name,
+            Information = model.Information,
+            Joined = model.Joined,
+            Regions = model.Regions,
+
         };
     }
 }

--- a/src/SFA.DAS.AANHub.Api/Models/CreateEmployerModel.cs
+++ b/src/SFA.DAS.AANHub.Api/Models/CreateEmployerModel.cs
@@ -8,7 +8,7 @@ namespace SFA.DAS.AANHub.Api.Models
         public long UserId { get; set; }
         public string? Organisation { get; set; }
         public DateTime Joined { get; set; }
-        public int[]? Regions { get; set; }
+        public List<int>? Regions { get; set; }
         public string? Information { get; set; }
         public string Email { get; set; } = null!;
         public string Name { get; set; } = null!;

--- a/src/SFA.DAS.AANHub.Application.UnitTests/Common/Validators/CreateMemberCommandBaseValidatorTests.cs
+++ b/src/SFA.DAS.AANHub.Application.UnitTests/Common/Validators/CreateMemberCommandBaseValidatorTests.cs
@@ -75,7 +75,10 @@ namespace SFA.DAS.AANHub.Application.UnitTests.Common.Validators
         [TestCase(new[] { 10 }, false)]
         public async Task Validates_Region_Range(int[] regions, bool isValid)
         {
-            var command = new CreateMemberCommand { Regions = regions };
+            var list = new List<int>();
+            list.AddRange(regions.Select(region => region));
+
+            var command = new CreateMemberCommand { Regions = list };
             var sut = new CreateMemberCommandBaseValidator(_regionsReadRepository.Object);
             _regionsReadRepository.Setup(m => m.GetAllRegions()).ReturnsAsync(_regions);
 

--- a/src/SFA.DAS.AANHub.Application.UnitTests/Employers/Commands/CreateEmployerMemberCommandHandlerTests.cs
+++ b/src/SFA.DAS.AANHub.Application.UnitTests/Employers/Commands/CreateEmployerMemberCommandHandlerTests.cs
@@ -5,7 +5,6 @@ using NUnit.Framework;
 using SFA.DAS.AANHub.Application.Employers.Commands;
 using SFA.DAS.AANHub.Domain.Entities;
 using SFA.DAS.AANHub.Domain.Enums;
-using SFA.DAS.AANHub.Domain.Interfaces;
 using SFA.DAS.AANHub.Domain.Interfaces.Repositories;
 
 namespace SFA.DAS.AANHub.Application.UnitTests.Employers.Commands
@@ -16,10 +15,27 @@ namespace SFA.DAS.AANHub.Application.UnitTests.Employers.Commands
         public async Task Handle_AddsNewEmployer(
             [Frozen] Mock<IMembersWriteRepository> membersWriteRepository,
             [Frozen] Mock<IAuditWriteRepository> auditWriteRepository,
-            [Frozen] Mock<IAanDataContext> aanContext,
             CreateEmployerMemberCommandHandler sut,
             CreateEmployerMemberCommand command)
         {
+            command.Regions = new List<int>(new[] { 1 });
+            var response = await sut.Handle(command, new CancellationToken());
+            response.MemberId.Should().Be(command.Id);
+            response.Status.Should().Be(MembershipStatus.Live.ToString());
+
+            membersWriteRepository.Verify(p => p.Create(It.Is<Member>(x => x.Id == command.Id)));
+            membersWriteRepository.Verify(p => p.Create(It.Is<Member>(x => x.MemberRegions != null && x.MemberRegions[0].RegionId == 1)));
+            auditWriteRepository.Verify(p => p.Create(It.Is<Audit>(x => x.ActionedBy == command.RequestedByUserId)));
+        }
+
+        [Test, AutoMoqData]
+        public async Task Handle_AddsNewEmployer_WithNullRegions(
+            [Frozen] Mock<IMembersWriteRepository> membersWriteRepository,
+            [Frozen] Mock<IAuditWriteRepository> auditWriteRepository,
+            CreateEmployerMemberCommandHandler sut,
+            CreateEmployerMemberCommand command)
+        {
+            command.Regions = null;
 
             var response = await sut.Handle(command, new CancellationToken());
             response.MemberId.Should().Be(command.Id);

--- a/src/SFA.DAS.AANHub.Application/Common/Commands/CreateMemberCommandBase.cs
+++ b/src/SFA.DAS.AANHub.Application/Common/Commands/CreateMemberCommandBase.cs
@@ -10,7 +10,7 @@ namespace SFA.DAS.AANHub.Application.Common.Commands
         public string? Email { get; set; }
         public string? Name { get; set; }
         public DateTime Joined { get; set; }
-        public int[]? Regions { get; set; }
+        public List<int>? Regions { get; set; }
         public string? Information { get; set; }
     }
 }

--- a/src/SFA.DAS.AANHub.Application/Employers/Commands/CreateEmployerMemberCommand.cs
+++ b/src/SFA.DAS.AANHub.Application/Employers/Commands/CreateEmployerMemberCommand.cs
@@ -23,6 +23,7 @@ namespace SFA.DAS.AANHub.Application.Employers.Commands
             ReviewStatus = MembershipReviewStatus.New,
             Deleted = null,
             Status = MembershipStatus.Live,
+            MemberRegions = Member.GenerateMemberRegions(command.Regions, command.Id),
             Employer = new Employer
             {
                 MemberId = command.Id,

--- a/src/SFA.DAS.AANHub.Application/Employers/Commands/CreateEmployerMemberCommandHandler.cs
+++ b/src/SFA.DAS.AANHub.Application/Employers/Commands/CreateEmployerMemberCommandHandler.cs
@@ -1,9 +1,9 @@
-﻿using MediatR;
+﻿using System.Text.Json;
+using MediatR;
 using SFA.DAS.AANHub.Domain.Entities;
 using SFA.DAS.AANHub.Domain.Enums;
 using SFA.DAS.AANHub.Domain.Interfaces;
 using SFA.DAS.AANHub.Domain.Interfaces.Repositories;
-using System.Text.Json;
 
 namespace SFA.DAS.AANHub.Application.Employers.Commands
 {

--- a/src/SFA.DAS.AANHub.Database/Tables/Member.sql
+++ b/src/SFA.DAS.AANHub.Database/Tables/Member.sql
@@ -4,11 +4,9 @@
     [UserType] NVARCHAR(10) NOT NULL, 
     [ReviewStatus] NVARCHAR(15) NULL, 
     [Status] NVARCHAR(10) NOT NULL, 
-    [Information] NVARCHAR(MAX) NULL, 
-    [RegionId] INT NULL, 
+    [Information] NVARCHAR(MAX) NULL,
     [Joined] DATETIME NOT NULL, 
     [Created] DATETIME NOT NULL DEFAULT GETUTCDATE(),
     [Updated] DATETIME NULL, 
-    [Deleted] DATETIME NULL 
-    CONSTRAINT [FK_Member_Region] FOREIGN KEY ([RegionId]) REFERENCES [Region]([Id])
+    [Deleted] DATETIME NULL
 )

--- a/src/SFA.DAS.AANHub.Domain/Entities/Member.cs
+++ b/src/SFA.DAS.AANHub.Domain/Entities/Member.cs
@@ -16,7 +16,7 @@ namespace SFA.DAS.AANHub.Domain.Entities
         public virtual Employer? Employer { get; set; }
         public virtual Partner? Partner { get; set; }
         public virtual List<MemberRegion>? MemberRegions { get; set; }
-        public static List<MemberRegion> GenerateMemberRegions(int[]? regions, Guid id)
+        public static List<MemberRegion> GenerateMemberRegions(List<int>? regions, Guid id)
         {
             var memberRegions = new List<MemberRegion>();
             if (regions == null) return memberRegions;

--- a/src/SFA.DAS.AANHub.Domain/Entities/Member.cs
+++ b/src/SFA.DAS.AANHub.Domain/Entities/Member.cs
@@ -16,5 +16,14 @@ namespace SFA.DAS.AANHub.Domain.Entities
         public virtual Employer? Employer { get; set; }
         public virtual Partner? Partner { get; set; }
         public virtual List<MemberRegion>? MemberRegions { get; set; }
+        public static List<MemberRegion> GenerateMemberRegions(int[]? regions, Guid id)
+        {
+            var memberRegions = new List<MemberRegion>();
+            if (regions == null) return memberRegions;
+
+            memberRegions.AddRange(regions.Select(region => new MemberRegion { MemberId = id, RegionId = region }));
+
+            return memberRegions;
+        }
     }
 }


### PR DESCRIPTION
Fixed issue where `Information` and `Name` were not being populated even when provided when sending requests.

Additionally, MembersRegion table was not being populated, which has since been fixed.

