### PR TITLE
CSP-505 - Refactor Fluent Validation middleware to not throw exception

### DIFF
--- a/src/SFA.DAS.AANHub.Api.UnitTests/Controllers/EmployersControllerTests.cs
+++ b/src/SFA.DAS.AANHub.Api.UnitTests/Controllers/EmployersControllerTests.cs
@@ -1,38 +1,64 @@
-﻿using AutoFixture.NUnit3;
-using FluentAssertions;
+﻿using FluentAssertions;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
 using SFA.DAS.AANHub.Api.Controllers;
 using SFA.DAS.AANHub.Api.Models;
 using SFA.DAS.AANHub.Application.Employers.Commands;
+using SFA.DAS.AANHub.Application.Mediatr.Responses;
 using SFA.DAS.AANHub.Application.UnitTests;
-using static SFA.DAS.AANHub.Domain.Common.Constants;
+using SFA.DAS.AANHub.Domain.Common;
 
 namespace SFA.DAS.AANHub.Api.UnitTests.Controllers
 {
     public class EmployersControllerTests
     {
+        private readonly Mock<IMediator> _mediator;
+        private readonly EmployersController _controller;
+        public EmployersControllerTests()
+        {
+            _mediator = new Mock<IMediator>();
+            _controller = new EmployersController(Mock.Of<ILogger<EmployersController>>(), _mediator.Object);
+
+        }
         [Test, AutoMoqData]
         public async Task CreateEmployer_InvokesRequest(
-            [Frozen] Mock<IMediator> mediatorMock,
-            [Greedy] EmployersController sut,
-            CreateEmployerModel model, CreateEmployerMemberCommand command, long userId, long accountId, string organisation)
+            CreateEmployerModel model,
+            CreateEmployerMemberCommand command)
         {
-            var response = new CreateEmployerMemberCommandResponse
+            var response = new ValidatableResponse<CreateEmployerMemberCommandResponse>
+            (new CreateEmployerMemberCommandResponse
             {
                 MemberId = command.Id,
-                Status = MembershipStatus.Live,
-            };
+                Status = Constants.MembershipStatus.Live,
+            });
 
             model.Regions = new List<int>(new[] { 1, 2, });
-            mediatorMock.Setup(m => m.Send(It.Is<CreateEmployerMemberCommand>(c => c.UserId == userId && c.Organisation == organisation && c.AccountId == accountId), It.IsAny<CancellationToken>())).ReturnsAsync(response);
-            var result = await sut.CreateEmployer(Guid.NewGuid(), model);
+            _mediator.Setup(m => m.Send(It.IsAny<CreateEmployerMemberCommand>(), It.IsAny<CancellationToken>())).ReturnsAsync(response);
+            var result = await _controller.CreateEmployer(Guid.NewGuid(), model);
 
             result.As<CreatedAtActionResult>().ControllerName.Should().Be("Employers");
             result.As<CreatedAtActionResult>().ActionName.Should().Be("CreateEmployer");
             result.As<CreatedAtActionResult>().StatusCode.Should().Be(201);
+        }
+
+        [Test, AutoMoqData]
+        public async Task CreateEmployer_InvokesRequest_WithErrors(
+            CreateEmployerMemberCommand command)
+        {
+            var response = new ValidatableResponse<CreateEmployerMemberCommandResponse>
+            (new CreateEmployerMemberCommandResponse
+            {
+                MemberId = command.Id,
+                Status = Constants.MembershipStatus.Live.ToString()
+            }, new List<string> { new string("Error") });
+            var model = new CreateEmployerModel();
+            _mediator.Setup(m => m.Send(It.IsAny<CreateEmployerMemberCommand>(), It.IsAny<CancellationToken>())).ReturnsAsync(response);
+            var result = await _controller.CreateEmployer(Guid.NewGuid(), model);
+
+            result.As<BadRequestObjectResult>().StatusCode.Should().Be(400);
         }
     }
 }

--- a/src/SFA.DAS.AANHub.Api/Controllers/EmployersController.cs
+++ b/src/SFA.DAS.AANHub.Api/Controllers/EmployersController.cs
@@ -36,7 +36,10 @@ namespace SFA.DAS.AANHub.Api.Controllers
             command.RequestedByUserId = userId;
 
             var response = await _mediator.Send(command);
-            return new CreatedAtActionResult(nameof(CreateEmployer), "Employers", new { id = response.MemberId }, response);
+
+            return response.IsValidResponse ? new CreatedAtActionResult(nameof(CreateEmployer), "Employers", new { id = response.Result.MemberId }, response.Result)
+            : new BadRequestObjectResult(response.Errors);
+
         }
     }
 }

--- a/src/SFA.DAS.AANHub.Application.UnitTests/Employers/Commands/CreateEmployerMemberCommandHandlerTests.cs
+++ b/src/SFA.DAS.AANHub.Application.UnitTests/Employers/Commands/CreateEmployerMemberCommandHandlerTests.cs
@@ -5,7 +5,6 @@ using NUnit.Framework;
 using SFA.DAS.AANHub.Application.Employers.Commands;
 using SFA.DAS.AANHub.Domain.Entities;
 using SFA.DAS.AANHub.Domain.Interfaces.Repositories;
-using static SFA.DAS.AANHub.Domain.Common.Constants;
 
 namespace SFA.DAS.AANHub.Application.UnitTests.Employers.Commands
 {
@@ -20,8 +19,8 @@ namespace SFA.DAS.AANHub.Application.UnitTests.Employers.Commands
         {
             command.Regions = new List<int>(new[] { 1 });
             var response = await sut.Handle(command, new CancellationToken());
-            response.MemberId.Should().Be(command.Id);
-            response.Status.Should().Be(MembershipStatus.Live.ToString());
+            response.Result.MemberId.Should().Be(command.Id);
+            response.Result.Status.Should().Be(Domain.Common.Constants.MembershipStatus.Live.ToString());
 
             membersWriteRepository.Verify(p => p.Create(It.Is<Member>(x => x.Id == command.Id)));
             membersWriteRepository.Verify(p => p.Create(It.Is<Member>(x => x.MemberRegions != null && x.MemberRegions[0].RegionId == 1)));
@@ -38,8 +37,9 @@ namespace SFA.DAS.AANHub.Application.UnitTests.Employers.Commands
             command.Regions = null;
 
             var response = await sut.Handle(command, new CancellationToken());
-            response.MemberId.Should().Be(command.Id);
-            response.Status.Should().Be(MembershipStatus.Live);
+
+            response.Result.MemberId.Should().Be(command.Id);
+            response.Result.Status.Should().Be(Domain.Common.Constants.MembershipStatus.Live.ToString());
 
             membersWriteRepository.Verify(p => p.Create(It.Is<Member>(x => x.Id == command.Id)));
             auditWriteRepository.Verify(p => p.Create(It.Is<Audit>(x => x.ActionedBy == command.RequestedByUserId)));

--- a/src/SFA.DAS.AANHub.Application/Employers/Commands/CreateEmployerMemberCommand.cs
+++ b/src/SFA.DAS.AANHub.Application/Employers/Commands/CreateEmployerMemberCommand.cs
@@ -1,11 +1,12 @@
 ﻿using MediatR;
 using SFA.DAS.AANHub.Application.Common.Commands;
+using SFA.DAS.AANHub.Application.Mediatr.Responses;
 using SFA.DAS.AANHub.Domain.Entities;
 using static SFA.DAS.AANHub.Domain.Common.Constants;
 
 namespace SFA.DAS.AANHub.Application.Employers.Commands
 {
-    public class CreateEmployerMemberCommand : CreateMemberCommandBase, IRequest<CreateEmployerMemberCommandResponse>
+    public class CreateEmployerMemberCommand : CreateMemberCommandBase, IRequest<ValidatableResponse<CreateEmployerMemberCommandResponse>>
     {
         public long AccountId { get; set; }
         public long UserId { get; set; }

--- a/src/SFA.DAS.AANHub.Application/Employers/Commands/CreateEmployerMemberCommandHandler.cs
+++ b/src/SFA.DAS.AANHub.Application/Employers/Commands/CreateEmployerMemberCommandHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Json;
 using MediatR;
+using SFA.DAS.AANHub.Application.Mediatr.Responses;
 using SFA.DAS.AANHub.Domain.Entities;
 using SFA.DAS.AANHub.Domain.Interfaces;
 using SFA.DAS.AANHub.Domain.Interfaces.Repositories;
@@ -7,7 +8,8 @@ using static SFA.DAS.AANHub.Domain.Common.Constants;
 
 namespace SFA.DAS.AANHub.Application.Employers.Commands
 {
-    public class CreateEmployerMemberCommandHandler : IRequestHandler<CreateEmployerMemberCommand, CreateEmployerMemberCommandResponse>
+    public class CreateEmployerMemberCommandHandler :
+        IRequestHandler<CreateEmployerMemberCommand, ValidatableResponse<CreateEmployerMemberCommandResponse>>
     {
         private readonly IMembersWriteRepository _membersWriteRepository;
         private readonly IAuditWriteRepository _auditWriteRepository;
@@ -21,7 +23,7 @@ namespace SFA.DAS.AANHub.Application.Employers.Commands
             _auditWriteRepository = auditWriteRepository;
         }
 
-        public async Task<CreateEmployerMemberCommandResponse> Handle(CreateEmployerMemberCommand command,
+        public async Task<ValidatableResponse<CreateEmployerMemberCommandResponse>> Handle(CreateEmployerMemberCommand command,
             CancellationToken cancellationToken)
         {
             Member member = command;
@@ -39,7 +41,7 @@ namespace SFA.DAS.AANHub.Application.Employers.Commands
 
             await _aanDataContext.SaveChangesAsync(cancellationToken);
 
-            return member;
+            return new ValidatableResponse<CreateEmployerMemberCommandResponse>(member);
         }
     }
 }

--- a/src/SFA.DAS.AANHub.Application/Mediatr/Responses/ValidatableResponse.cs
+++ b/src/SFA.DAS.AANHub.Application/Mediatr/Responses/ValidatableResponse.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
+
+namespace SFA.DAS.AANHub.Application.Mediatr.Responses
+{
+    [ExcludeFromCodeCoverage]
+    public class ValidatableResponse
+    {
+        private readonly IList<string> _errorMessages;
+
+        public ValidatableResponse(IList<string>? errors = null) => _errorMessages = errors ?? new List<string>();
+
+        public bool IsValidResponse => !_errorMessages.Any();
+
+        public IReadOnlyCollection<string> Errors => new ReadOnlyCollection<string>(_errorMessages);
+    }
+    [ExcludeFromCodeCoverage]
+    public class ValidatableResponse<TModel> : ValidatableResponse
+        where TModel : class
+    {
+        public ValidatableResponse() { }
+        public ValidatableResponse(TModel model, IList<string>? validationErrors = null)
+            : base(validationErrors) => Result = model;
+
+        public TModel Result { get; } = null!;
+    }
+}


### PR DESCRIPTION
Mediatr middleware validation now handled without throwing errors, and clogging logs with false positives.

Responses are now wrapped in [ValidatableResponse](src/SFA.DAS.AANHub.Application/Mediatr/Responses/ValidatableResponse.cs), with errors, and `IsValid` bool accessible within response.

Future improvements:
- ValidationBehaviour.cs` trace logs should be updated to include `RequestedByUserId` when that information is available, and accessible in API.