### PR TITLE
CSP-535 - RequestedByMember & AccountId/UserId pair check

### DIFF
--- a/src/SFA.DAS.AANHub.Api.UnitTests/Controllers/WhenPostingCreateMember.cs
+++ b/src/SFA.DAS.AANHub.Api.UnitTests/Controllers/WhenPostingCreateMember.cs
@@ -24,18 +24,6 @@ namespace SFA.DAS.AANHub.Api.UnitTests.Controllers
         }
 
         [Test, AutoMoqData]
-        public async Task And_MediatorApprenticeCommandSuccessful_Then_ReturnOk(
-            CreateMemberCommand command,
-            CreateMemberResponse response
-            )
-        {
-            command.UserType = MembershipUserType.Apprentice;
-            _mediator.Setup(m => m.Send(command, It.IsAny<CancellationToken>())).ReturnsAsync(response);
-            var result = await _controller.CreateApprenticeMember(command);
-            ApplyTests(result, response);
-        }
-
-        [Test, AutoMoqData]
         public async Task And_MediatorPartnerCommandSuccessful_Then_ReturnOk(
             CreateMemberCommand command,
             CreateMemberResponse response

--- a/src/SFA.DAS.AANHub.Api/Controllers/EmployersController.cs
+++ b/src/SFA.DAS.AANHub.Api/Controllers/EmployersController.cs
@@ -33,7 +33,7 @@ namespace SFA.DAS.AANHub.Api.Controllers
             _logger.LogInformation("AAN Hub API: Received command to add employer by accountId: {accountId} and UserId: {userId}:", request.AccountId, request.UserId);
 
             CreateEmployerMemberCommand command = request;
-            command.RequestedByUserId = userId;
+            command.RequestedByMemberId = userId;
 
             var response = await _mediator.Send(command);
             return new CreatedAtActionResult(nameof(CreateEmployer), "Employers", new { id = response.MemberId }, response);

--- a/src/SFA.DAS.AANHub.Api/Controllers/MemberController.cs
+++ b/src/SFA.DAS.AANHub.Api/Controllers/MemberController.cs
@@ -25,17 +25,6 @@ namespace SFA.DAS.AANHub.Api.Controllers
         [Route("{id}")]
         public ActionResult<Member> GetMember(Guid id) => Ok(new Member() { Id = id });
 
-        [HttpPost("apprentice")]
-        [Produces("application/json")]
-        [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(typeof(string), StatusCodes.Status404NotFound)]
-        [ProducesResponseType(typeof(CreateMemberApiResponse), 200)]
-        public async Task<IActionResult> CreateApprenticeMember([FromBody] CreateMemberCommand request)
-        {
-            request.UserType = MembershipUserType.Apprentice;
-            return await CreateMember(request);
-        }
-
         [HttpPost("partner")]
         [Produces("application/json")]
         [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]

--- a/src/SFA.DAS.AANHub.Application.UnitTests/Commands/Members/WhenPostingMember.cs
+++ b/src/SFA.DAS.AANHub.Application.UnitTests/Commands/Members/WhenPostingMember.cs
@@ -13,7 +13,6 @@ namespace SFA.DAS.AANHub.Application.UnitTests.Commands.Members
     {
         private readonly CreateMemberCommandHandler _handler;
         private readonly Mock<IMembersWriteRepository> _membersWriteRepository;
-        private readonly Mock<IApprenticesWriteRepository> _apprenticesWriteRepository;
         private readonly Mock<IAdminsWriteRepository> _adminsWriteRepository;
         private readonly Mock<IPartnersWriteRepository> _partnersWriteRepository;
         private readonly Mock<IAuditWriteRepository> _auditWriteRepository;
@@ -24,12 +23,11 @@ namespace SFA.DAS.AANHub.Application.UnitTests.Commands.Members
 
             _membersWriteRepository = new Mock<IMembersWriteRepository>();
             _adminsWriteRepository = new Mock<IAdminsWriteRepository>();
-            _apprenticesWriteRepository = new Mock<IApprenticesWriteRepository>();
             _partnersWriteRepository = new Mock<IPartnersWriteRepository>();
             _auditWriteRepository = new Mock<IAuditWriteRepository>();
             _aanDataContext = new Mock<IAanDataContext>();
 
-            _handler = new CreateMemberCommandHandler(_membersWriteRepository.Object, _apprenticesWriteRepository.Object, _partnersWriteRepository.Object, _adminsWriteRepository.Object, _auditWriteRepository.Object, _aanDataContext.Object);
+            _handler = new CreateMemberCommandHandler(_membersWriteRepository.Object, _partnersWriteRepository.Object, _adminsWriteRepository.Object, _auditWriteRepository.Object, _aanDataContext.Object);
         }
 
         [Test, AutoMoqData]
@@ -76,7 +74,6 @@ namespace SFA.DAS.AANHub.Application.UnitTests.Commands.Members
         )
         {
             _membersWriteRepository.Setup(m => m.Create(It.IsAny<Member>()));
-            _apprenticesWriteRepository.Setup(m => m.Create(It.IsAny<Apprentice>()));
             _adminsWriteRepository.Setup(m => m.Create(It.IsAny<Admin>()));
             _partnersWriteRepository.Setup(m => m.Create(It.IsAny<Partner>()));
             _auditWriteRepository.Setup(m => m.Create(It.IsAny<Audit>()));

--- a/src/SFA.DAS.AANHub.Application.UnitTests/Employers/Commands/CreateEmployerMemberCommandHandlerTests.cs
+++ b/src/SFA.DAS.AANHub.Application.UnitTests/Employers/Commands/CreateEmployerMemberCommandHandlerTests.cs
@@ -25,7 +25,7 @@ namespace SFA.DAS.AANHub.Application.UnitTests.Employers.Commands
 
             membersWriteRepository.Verify(p => p.Create(It.Is<Member>(x => x.Id == command.Id)));
             membersWriteRepository.Verify(p => p.Create(It.Is<Member>(x => x.MemberRegions != null && x.MemberRegions[0].RegionId == 1)));
-            auditWriteRepository.Verify(p => p.Create(It.Is<Audit>(x => x.ActionedBy == command.RequestedByUserId)));
+            auditWriteRepository.Verify(p => p.Create(It.Is<Audit>(x => x.ActionedBy == command.RequestedByMemberId)));
         }
 
         [Test, AutoMoqData]
@@ -42,7 +42,7 @@ namespace SFA.DAS.AANHub.Application.UnitTests.Employers.Commands
             response.Status.Should().Be(MembershipStatus.Live);
 
             membersWriteRepository.Verify(p => p.Create(It.Is<Member>(x => x.Id == command.Id)));
-            auditWriteRepository.Verify(p => p.Create(It.Is<Audit>(x => x.ActionedBy == command.RequestedByUserId)));
+            auditWriteRepository.Verify(p => p.Create(It.Is<Audit>(x => x.ActionedBy == command.RequestedByMemberId)));
         }
     }
 }

--- a/src/SFA.DAS.AANHub.Application.UnitTests/Employers/Commands/CreateEmployerMemberCommandValidatorTests.cs
+++ b/src/SFA.DAS.AANHub.Application.UnitTests/Employers/Commands/CreateEmployerMemberCommandValidatorTests.cs
@@ -9,8 +9,15 @@ namespace SFA.DAS.AANHub.Application.UnitTests.Employers.Commands
     public class CreateEmployerMemberCommandValidatorTests
     {
         private readonly Mock<IRegionsReadRepository> _regionsReadRepository;
+        private readonly Mock<IMembersReadRepository> _membersReadRepository;
+        private readonly Mock<IEmployersReadRepository> _employersReadRepository;
 
-        public CreateEmployerMemberCommandValidatorTests() => _regionsReadRepository = new Mock<IRegionsReadRepository>();
+        public CreateEmployerMemberCommandValidatorTests()
+        {
+            _regionsReadRepository = new Mock<IRegionsReadRepository>();
+            _membersReadRepository = new Mock<IMembersReadRepository>();
+            _employersReadRepository = new Mock<IEmployersReadRepository>();
+        }
 
         [TestCase(123, true)]
         [TestCase(null, false)]
@@ -19,7 +26,7 @@ namespace SFA.DAS.AANHub.Application.UnitTests.Employers.Commands
         {
 
             var command = new CreateEmployerMemberCommand() { UserId = id };
-            var sut = new CreateEmployerMemberCommandValidator(_regionsReadRepository.Object);
+            var sut = new CreateEmployerMemberCommandValidator(_regionsReadRepository.Object, _membersReadRepository.Object, _employersReadRepository.Object);
 
             var result = await sut.TestValidateAsync(command);
 
@@ -35,7 +42,7 @@ namespace SFA.DAS.AANHub.Application.UnitTests.Employers.Commands
         {
 
             var command = new CreateEmployerMemberCommand() { Organisation = organisation };
-            var sut = new CreateEmployerMemberCommandValidator(_regionsReadRepository.Object);
+            var sut = new CreateEmployerMemberCommandValidator(_regionsReadRepository.Object, _membersReadRepository.Object, _employersReadRepository.Object);
 
             var result = await sut.TestValidateAsync(command);
 
@@ -50,7 +57,7 @@ namespace SFA.DAS.AANHub.Application.UnitTests.Employers.Commands
         {
 
             var command = new CreateEmployerMemberCommand() { Organisation = new string('a', stringLength) };
-            var sut = new CreateEmployerMemberCommandValidator(_regionsReadRepository.Object);
+            var sut = new CreateEmployerMemberCommandValidator(_regionsReadRepository.Object, _membersReadRepository.Object, _employersReadRepository.Object);
 
             var result = await sut.TestValidateAsync(command);
 
@@ -66,7 +73,7 @@ namespace SFA.DAS.AANHub.Application.UnitTests.Employers.Commands
         {
 
             var command = new CreateEmployerMemberCommand() { AccountId = id };
-            var sut = new CreateEmployerMemberCommandValidator(_regionsReadRepository.Object);
+            var sut = new CreateEmployerMemberCommandValidator(_regionsReadRepository.Object, _membersReadRepository.Object, _employersReadRepository.Object);
 
             var result = await sut.TestValidateAsync(command);
 
@@ -75,40 +82,40 @@ namespace SFA.DAS.AANHub.Application.UnitTests.Employers.Commands
             else
                 result.ShouldHaveValidationErrorFor(c => c.AccountId);
         }
-        [TestCaseSource(nameof(GuidTestCases))]
+        [TestCaseSource(nameof(FailGuidTestCases))]
         public async Task Validates_RequestedByUserId_NotEmptyGuid(Guid? id, bool isValid)
         {
 
-            var command = new CreateEmployerMemberCommand() { RequestedByUserId = id };
+            var command = new CreateEmployerMemberCommand() { RequestedByMemberId = id };
 
-            var sut = new CreateEmployerMemberCommandValidator(_regionsReadRepository.Object);
+            var sut = new CreateEmployerMemberCommandValidator(_regionsReadRepository.Object, _membersReadRepository.Object, _employersReadRepository.Object);
 
             var result = await sut.TestValidateAsync(command);
 
             if (isValid)
-                result.ShouldNotHaveValidationErrorFor(c => c.RequestedByUserId);
+                result.ShouldNotHaveValidationErrorFor(c => c.RequestedByMemberId);
             else
-                result.ShouldHaveValidationErrorFor(c => c.RequestedByUserId);
+                result.ShouldHaveValidationErrorFor(c => c.RequestedByMemberId);
         }
         [TestCase(null, false)]
         public async Task Validates_RequestedByUserId_NotNull(Guid? id, bool isValid)
         {
 
-            var command = new CreateEmployerMemberCommand() { RequestedByUserId = id };
+            var command = new CreateEmployerMemberCommand() { RequestedByMemberId = id };
 
-            var sut = new CreateEmployerMemberCommandValidator(_regionsReadRepository.Object);
+            var sut = new CreateEmployerMemberCommandValidator(_regionsReadRepository.Object, _membersReadRepository.Object, _employersReadRepository.Object);
 
             var result = await sut.TestValidateAsync(command);
 
             if (isValid)
-                result.ShouldNotHaveValidationErrorFor(c => c.RequestedByUserId);
+                result.ShouldNotHaveValidationErrorFor(c => c.RequestedByMemberId);
             else
-                result.ShouldHaveValidationErrorFor(c => c.RequestedByUserId);
+                result.ShouldHaveValidationErrorFor(c => c.RequestedByMemberId);
         }
 
-        private static readonly object[] GuidTestCases =
+        private static readonly object[] FailGuidTestCases =
         {
-            new object[]{ Guid.NewGuid(), true },
+            new object[]{ Guid.NewGuid(), false },
             new object[]{ Guid.Empty, false},
         };
     }

--- a/src/SFA.DAS.AANHub.Application/Commands/CreateMember/CreateMemberCommandHandler.cs
+++ b/src/SFA.DAS.AANHub.Application/Commands/CreateMember/CreateMemberCommandHandler.cs
@@ -1,30 +1,27 @@
-﻿using MediatR;
+﻿using System.Text.Json;
+using MediatR;
 using SFA.DAS.AANHub.Domain.Entities;
 using SFA.DAS.AANHub.Domain.Interfaces;
 using SFA.DAS.AANHub.Domain.Interfaces.Repositories;
 using static SFA.DAS.AANHub.Domain.Common.Constants;
-using System.Text.Json;
 
 namespace SFA.DAS.AANHub.Application.Commands.CreateMember
 {
     public class CreateMemberCommandHandler : IRequestHandler<CreateMemberCommand, CreateMemberResponse>
     {
         private readonly IMembersWriteRepository _membersWriteRepository;
-        private readonly IApprenticesWriteRepository _apprenticesWriteRepository;
         private readonly IPartnersWriteRepository _partnersWriteRepository;
         private readonly IAdminsWriteRepository _adminsWriteRepository;
         private readonly IAuditWriteRepository _auditWriteRepository;
         private readonly IAanDataContext _aanDataContext;
         public CreateMemberCommandHandler(
             IMembersWriteRepository membersWriteRepository,
-            IApprenticesWriteRepository apprenticesRepository,
             IPartnersWriteRepository partnersWriteRepository,
             IAdminsWriteRepository adminsWriteRepository,
             IAuditWriteRepository auditWriteRepository,
             IAanDataContext aanDataContext)
         {
             _membersWriteRepository = membersWriteRepository;
-            _apprenticesWriteRepository = apprenticesRepository;
             _partnersWriteRepository = partnersWriteRepository;
             _adminsWriteRepository = adminsWriteRepository;
             _auditWriteRepository = auditWriteRepository;
@@ -61,18 +58,6 @@ namespace SFA.DAS.AANHub.Application.Commands.CreateMember
 
             switch (command.UserType)
             {
-                case MembershipUserType.Apprentice:
-                    _apprenticesWriteRepository.Create(
-                        new Apprentice()
-                        {
-                            MemberId = memberId,
-                            Email = null,
-                            Name = null,
-                            LastUpdated = DateTime.Now,
-                            IsActive = true
-                        });
-                    break;
-
                 case MembershipUserType.Partner:
                     _partnersWriteRepository.Create(
                         new Partner()

--- a/src/SFA.DAS.AANHub.Application/Common/Validators/RequestedByMemberId/RequestedByMemberIdValidator.cs
+++ b/src/SFA.DAS.AANHub.Application/Common/Validators/RequestedByMemberId/RequestedByMemberIdValidator.cs
@@ -8,18 +8,15 @@ namespace SFA.DAS.AANHub.Application.Common.Validators.RequestedByMemberId
     {
         public const string RequestedByMemberIdEmptyErrorMessage = "RequestedByMemberId is empty";
         public const string RequestedByMemberIdNotFoundMessage = "RequestedByMemberId was not found";
-        public RequestedByMemberIdValidator(IMembersReadRepository membersReadRepository)
-        {
-            RuleFor(x => x.RequestedByMemberId)
+        public RequestedByMemberIdValidator(IMembersReadRepository membersReadRepository) => RuleFor(x => x.RequestedByMemberId)
                 .NotNull()
                 .NotEmpty()
                 .WithMessage(RequestedByMemberIdEmptyErrorMessage)
-                .MustAsync(async (RequestedByMemberId, cancellation) =>
+                .MustAsync(async (requestedByMemberId, cancellation) =>
                 {
-                    var member = await membersReadRepository.GetMember(RequestedByMemberId);
-                    return member != null && member.Status == MembershipStatus.Live;
+                    var member = await membersReadRepository.GetMember(requestedByMemberId);
+                    return member is { Status: MembershipStatus.Live };
                 })
                 .WithMessage(RequestedByMemberIdNotFoundMessage);
-        }
     }
 }

--- a/src/SFA.DAS.AANHub.Application/Employers/Commands/CreateEmployerMemberCommand.cs
+++ b/src/SFA.DAS.AANHub.Application/Employers/Commands/CreateEmployerMemberCommand.cs
@@ -1,16 +1,17 @@
 ﻿using MediatR;
 using SFA.DAS.AANHub.Application.Common.Commands;
+using SFA.DAS.AANHub.Application.Common.Validators.RequestedByMemberId;
 using SFA.DAS.AANHub.Domain.Entities;
 using static SFA.DAS.AANHub.Domain.Common.Constants;
 
 namespace SFA.DAS.AANHub.Application.Employers.Commands
 {
-    public class CreateEmployerMemberCommand : CreateMemberCommandBase, IRequest<CreateEmployerMemberCommandResponse>
+    public class CreateEmployerMemberCommand : CreateMemberCommandBase, IRequest<CreateEmployerMemberCommandResponse>, IRequestedByMemberId
     {
         public long AccountId { get; set; }
         public long UserId { get; set; }
         public string? Organisation { get; set; }
-        public Guid? RequestedByUserId { get; set; }
+        public Guid? RequestedByMemberId { get; set; }
 
         public static implicit operator Member(CreateEmployerMemberCommand command) => new()
         {
@@ -36,6 +37,5 @@ namespace SFA.DAS.AANHub.Application.Employers.Commands
                 IsActive = true
             }
         };
-
     }
 }

--- a/src/SFA.DAS.AANHub.Application/Employers/Commands/CreateEmployerMemberCommandHandler.cs
+++ b/src/SFA.DAS.AANHub.Application/Employers/Commands/CreateEmployerMemberCommandHandler.cs
@@ -31,7 +31,7 @@ namespace SFA.DAS.AANHub.Application.Employers.Commands
             _auditWriteRepository.Create(new Audit
             {
                 Action = "Create",
-                ActionedBy = command.RequestedByUserId ?? Guid.Empty,
+                ActionedBy = command.RequestedByMemberId ?? Guid.Empty,
                 AuditTime = DateTime.UtcNow,
                 After = JsonSerializer.Serialize(member),
                 Resource = MembershipUserType.Employer

--- a/src/SFA.DAS.AANHub.Application/Employers/Commands/CreateEmployerMemberCommandResponse.cs
+++ b/src/SFA.DAS.AANHub.Application/Employers/Commands/CreateEmployerMemberCommandResponse.cs
@@ -10,7 +10,7 @@ namespace SFA.DAS.AANHub.Application.Employers.Commands
         public static implicit operator CreateEmployerMemberCommandResponse(Member member) => new()
         {
             MemberId = member.Id,
-            Status = member.Status.ToString()
+            Status = member.Status?.ToString()
         };
     }
 }

--- a/src/SFA.DAS.AANHub.Application/Employers/Commands/CreateEmployerMemberCommandValidator.cs
+++ b/src/SFA.DAS.AANHub.Application/Employers/Commands/CreateEmployerMemberCommandValidator.cs
@@ -1,14 +1,16 @@
 ﻿using FluentValidation;
 using SFA.DAS.AANHub.Application.Common.Validators;
+using SFA.DAS.AANHub.Application.Common.Validators.RequestedByMemberId;
 using SFA.DAS.AANHub.Domain.Interfaces.Repositories;
 
 namespace SFA.DAS.AANHub.Application.Employers.Commands
 {
     public class CreateEmployerMemberCommandValidator : AbstractValidator<CreateEmployerMemberCommand>
     {
-        public CreateEmployerMemberCommandValidator(IRegionsReadRepository regionsReadRepository)
+        public CreateEmployerMemberCommandValidator(IRegionsReadRepository regionsReadRepository, IMembersReadRepository membersReadRepository, IEmployersReadRepository employersReadRepository)
         {
             Include(new CreateMemberCommandBaseValidator(regionsReadRepository));
+            Include(new RequestedByMemberIdValidator(membersReadRepository));
             RuleFor(c => c.UserId)
                 .NotEmpty();
             RuleFor(c => c.Organisation)
@@ -16,8 +18,16 @@ namespace SFA.DAS.AANHub.Application.Employers.Commands
                 .MaximumLength(250);
             RuleFor(c => c.AccountId)
                 .NotEmpty();
-            RuleFor(c => c.RequestedByUserId).NotEqual(Guid.Empty).NotNull();
+            RuleFor(c => c)
+                .NotEmpty()
+                .MustAsync(async (command, cancellation) => await DoesUserAndAccountExist(command.AccountId, command.UserId, employersReadRepository))
+                .WithMessage("UserId and AccountId pair already exist");
         }
 
+        private static async Task<bool> DoesUserAndAccountExist(long accountId, long userId, IEmployersReadRepository employersReadRepository)
+        {
+            var result = await employersReadRepository.GetEmployerByAccountIdAndUserId(accountId, userId);
+            return result == null;
+        }
     }
 }

--- a/src/SFA.DAS.AANHub.Application/Responses/CreateMemberApiResponse.cs
+++ b/src/SFA.DAS.AANHub.Application/Responses/CreateMemberApiResponse.cs
@@ -1,8 +1,10 @@
 ﻿
+using System.Diagnostics.CodeAnalysis;
 using SFA.DAS.AANHub.Application.Commands.CreateMember;
 
 namespace SFA.DAS.AANHub.Application.Responses
 {
+    [ExcludeFromCodeCoverage]
     public class CreateMemberApiResponse
     {
         public Guid MemberId { get; set; }
@@ -18,8 +20,8 @@ namespace SFA.DAS.AANHub.Application.Responses
             }
 
             MemberId = result.Member.Id;
-            UserType = result.Member.UserType.ToString();
-            Status = result.Member.Status.ToString();
+            UserType = result.Member.UserType?.ToString();
+            Status = result.Member.Status?.ToString();
             Created = result.Member.Created;
         }
     }

--- a/src/SFA.DAS.AANHub.Data/Extensions/ServiceCollectionExtensions.cs
+++ b/src/SFA.DAS.AANHub.Data/Extensions/ServiceCollectionExtensions.cs
@@ -1,11 +1,11 @@
-﻿using Microsoft.Azure.Services.AppAuthentication;
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.Azure.Services.AppAuthentication;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using SFA.DAS.AANHub.Data.Repositories;
 using SFA.DAS.AANHub.Domain.Interfaces;
 using SFA.DAS.AANHub.Domain.Interfaces.Repositories;
-using System.Diagnostics.CodeAnalysis;
 
 namespace SFA.DAS.AANHub.Data.Extensions
 {
@@ -38,6 +38,7 @@ namespace SFA.DAS.AANHub.Data.Extensions
             services.AddTransient<IRegionsReadRepository, RegionsReadRepository>();
             services.AddTransient<IAdminsWriteRepository, AdminsWriteRepository>();
             services.AddTransient<IEmployersWriteRepository, EmployersWriteRepository>();
+            services.AddTransient<IEmployersReadRepository, EmployersReadRepository>();
             services.AddTransient<IApprenticesWriteRepository, ApprenticesWriteRepository>();
             services.AddTransient<IApprenticesReadRepository, ApprenticesReadRepository>();
             services.AddTransient<IPartnersWriteRepository, PartnersWriteRepository>();

--- a/src/SFA.DAS.AANHub.Data/Repositories/EmployersReadRepository.cs
+++ b/src/SFA.DAS.AANHub.Data/Repositories/EmployersReadRepository.cs
@@ -1,0 +1,20 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore;
+using SFA.DAS.AANHub.Domain.Entities;
+using SFA.DAS.AANHub.Domain.Interfaces.Repositories;
+
+namespace SFA.DAS.AANHub.Data.Repositories
+{
+    [ExcludeFromCodeCoverage]
+    internal class EmployersReadRepository : IEmployersReadRepository
+    {
+        private readonly AanDataContext _aanDataContext;
+
+        public EmployersReadRepository(AanDataContext aanDataContext) => _aanDataContext = aanDataContext;
+
+        public async Task<Employer?> GetEmployerByAccountIdAndUserId(long accountId, long userId) => await _aanDataContext
+            .Employers
+            .AsNoTracking().Where(m => m.AccountId == accountId && m.UserId == userId)
+            .SingleOrDefaultAsync();
+    }
+}

--- a/src/SFA.DAS.AANHub.Data/Repositories/MembersReadRepository.cs
+++ b/src/SFA.DAS.AANHub.Data/Repositories/MembersReadRepository.cs
@@ -12,9 +12,9 @@ namespace SFA.DAS.AANHub.Data.Repositories
 
         public MembersReadRepository(AanDataContext aanDataContext) => _aanDataContext = aanDataContext;
 
-        public async Task<Member?> GetMember(Guid? Id) => await _aanDataContext
+        public async Task<Member?> GetMember(Guid? id) => await _aanDataContext
                 .Members
-                .AsNoTracking().Where(m => m.Id == Id)
+                .AsNoTracking().Where(m => m.Id == id)
                 .SingleOrDefaultAsync();
     }
 }

--- a/src/SFA.DAS.AANHub.Domain/Interfaces/Repositories/IEmployersReadRepository.cs
+++ b/src/SFA.DAS.AANHub.Domain/Interfaces/Repositories/IEmployersReadRepository.cs
@@ -1,0 +1,9 @@
+﻿using SFA.DAS.AANHub.Domain.Entities;
+
+namespace SFA.DAS.AANHub.Domain.Interfaces.Repositories
+{
+    public interface IEmployersReadRepository
+    {
+        Task<Employer?> GetEmployerByAccountIdAndUserId(long accountId, long userId);
+    }
+}

--- a/src/SFA.DAS.AANHub.Domain/Interfaces/Repositories/IMembersReadRepository.cs
+++ b/src/SFA.DAS.AANHub.Domain/Interfaces/Repositories/IMembersReadRepository.cs
@@ -4,6 +4,6 @@ namespace SFA.DAS.AANHub.Domain.Interfaces.Repositories
 {
     public interface IMembersReadRepository
     {
-        Task<Member?> GetMember(Guid? Id);
+        Task<Member?> GetMember(Guid? id);
     }
 }

--- a/src/SFA.DAS.AANHub.Domain/SFA.DAS.AANHub.Domain.csproj
+++ b/src/SFA.DAS.AANHub.Domain/SFA.DAS.AANHub.Domain.csproj
@@ -7,15 +7,17 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Enums\**" />
+    <EmbeddedResource Remove="Enums\**" />
+    <None Remove="Enums\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Enums\" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
2 additional checks when creating an employer member

- RequestedByMember check from CreateApprentice
- Check to ensure AccountId and UserId don't exist in Employer table within the same row already