### PR TITLE
CSP-566-Added status in employers,partners,admins,apprentices

### DIFF
--- a/src/SFA.DAS.AANHub.Application.UnitTests/Admins/Queries/GetAdminMemberQueryHandlerTests.cs
+++ b/src/SFA.DAS.AANHub.Application.UnitTests/Admins/Queries/GetAdminMemberQueryHandlerTests.cs
@@ -19,7 +19,8 @@ namespace SFA.DAS.AANHub.Application.UnitTests.Admins.Queries
             {
                 Name = "ThisIsAName",
                 MemberId = Guid.NewGuid(),
-                Email = "email@email.com"
+                Email = "email@email.com",
+                Member = new Member() { Status = "live" }
             };
 
             adminReadRepositoryMock.Setup(a => a.GetAdminByUserName(adminUserName)).ReturnsAsync(admin);
@@ -30,6 +31,7 @@ namespace SFA.DAS.AANHub.Application.UnitTests.Admins.Queries
             Assert.AreEqual(admin.MemberId, result.Result.MemberId);
             Assert.AreEqual(admin.Name, result.Result.Name);
             Assert.AreEqual(admin.Email, result.Result.Email);
+            Assert.AreEqual(admin.Member.Status, result.Result.Status);
         }
     }
 }

--- a/src/SFA.DAS.AANHub.Application.UnitTests/Apprentices/Queries/GetApprenticeMemberQueryHandlerTests.cs
+++ b/src/SFA.DAS.AANHub.Application.UnitTests/Apprentices/Queries/GetApprenticeMemberQueryHandlerTests.cs
@@ -13,16 +13,24 @@ namespace SFA.DAS.AANHub.Application.UnitTests.Apprentices.Queries
         public async Task Handle_GetApprenticeMember()
         {
             long apprenticeId = 0;
-            Guid memberid = new();
 
             var apprenticesReadRepositoryMock = new Mock<IApprenticesReadRepository>();
-            var apprentice = new Apprentice();
+            var apprentice = new Apprentice
+            {
+                Name = "ThisIsAName",
+                MemberId = Guid.NewGuid(),
+                Email = "email@email.com",
+                Member = new Member() { Status = "live" }
+            };
             apprenticesReadRepositoryMock.Setup(a => a.GetApprentice(apprenticeId)).ReturnsAsync(apprentice);
             var sut = new GetApprenticeMemberQueryHandler(apprenticesReadRepositoryMock.Object);
 
             var result = await sut.Handle(new GetApprenticeMemberQuery(apprenticeId), new CancellationToken());
 
-            Assert.AreEqual(memberid, result.Result.MemberId);
+            Assert.AreEqual(apprentice.MemberId, result.Result.MemberId);
+            Assert.AreEqual(apprentice.Name, result.Result.Name);
+            Assert.AreEqual(apprentice.Email, result.Result.Email);
+            Assert.AreEqual(apprentice.Member.Status, result.Result.Status);
         }
     }
 }

--- a/src/SFA.DAS.AANHub.Application.UnitTests/Apprentices/Queries/GetApprenticeMemberResultTest.cs
+++ b/src/SFA.DAS.AANHub.Application.UnitTests/Apprentices/Queries/GetApprenticeMemberResultTest.cs
@@ -17,7 +17,7 @@ namespace SFA.DAS.AANHub.Application.UnitTests.Apprentices.Queries
             Assert.AreEqual(apprentice.MemberId, response!.MemberId);
             Assert.AreEqual(apprentice.Name, response.Name);
             Assert.AreEqual(apprentice.Email, response.Email);
-
+            Assert.AreEqual(apprentice.Member.Status, response.Status);
         }
 
         [Test, AutoMoqData]

--- a/src/SFA.DAS.AANHub.Application.UnitTests/Employers/Queries/GetEmployerMemberQueryHandlerTests.cs
+++ b/src/SFA.DAS.AANHub.Application.UnitTests/Employers/Queries/GetEmployerMemberQueryHandlerTests.cs
@@ -15,6 +15,7 @@ namespace SFA.DAS.AANHub.Application.UnitTests.Employers.Queries
             var name = "name";
             var email = "email@email.com";
             var organisation = "w3c";
+            var status = "live";
 
             var userRef = new Guid();
             Guid memberId = new();
@@ -24,7 +25,8 @@ namespace SFA.DAS.AANHub.Application.UnitTests.Employers.Queries
             {
                 Name = name,
                 Email = email,
-                Organisation = organisation
+                Organisation = organisation,
+                Member = new Member() { Status = status }
             };
 
             employersReadRepositoryMock.Setup(a => a.GetEmployerByUserRef(userRef)).ReturnsAsync(employer);
@@ -36,6 +38,7 @@ namespace SFA.DAS.AANHub.Application.UnitTests.Employers.Queries
             Assert.AreEqual(name, result!.Result.Name);
             Assert.AreEqual(email, result!.Result.Email);
             Assert.AreEqual(organisation, result!.Result.Organisation);
+            Assert.AreEqual(status, result!.Result.Status);
         }
 
         [Test]

--- a/src/SFA.DAS.AANHub.Application.UnitTests/Employers/Queries/GetEmployerMemberResultTest.cs
+++ b/src/SFA.DAS.AANHub.Application.UnitTests/Employers/Queries/GetEmployerMemberResultTest.cs
@@ -18,6 +18,7 @@ namespace SFA.DAS.AANHub.Application.UnitTests.Employers.Queries
             Assert.AreEqual(employer.Name, response.Name);
             Assert.AreEqual(employer.Email, response.Email);
             Assert.AreEqual(employer.Organisation, response.Organisation);
+            Assert.AreEqual(employer.Member.Status, response.Status);
         }
 
         [Test, AutoMoqData]

--- a/src/SFA.DAS.AANHub.Application.UnitTests/Partners/Queries/GetPartnerMemberQueryHandlerTests.cs
+++ b/src/SFA.DAS.AANHub.Application.UnitTests/Partners/Queries/GetPartnerMemberQueryHandlerTests.cs
@@ -17,14 +17,17 @@ namespace SFA.DAS.AANHub.Application.UnitTests.Partners.Queries
             string email = "email@email.com";
             string name = "lorem epsum";
             string organisation = "w3c";
+            string status = "live";
             Guid memberid = new();
 
             var partnersReadRepositoryMock = new Mock<IPartnersReadRepository>();
-            var partner = new Partner() {
+            var partner = new Partner()
+            {
                 MemberId = memberid,
                 Organisation = organisation,
                 Name = name,
-                Email = email
+                Email = email,
+                Member = new Member() { Status = status }
             };
 
             partnersReadRepositoryMock.Setup(a => a.GetPartnerByUserName(userName)).ReturnsAsync(partner);
@@ -36,6 +39,7 @@ namespace SFA.DAS.AANHub.Application.UnitTests.Partners.Queries
             Assert.AreEqual(email, result!.Result.Email);
             Assert.AreEqual(name, result!.Result.Name);
             Assert.AreEqual(organisation, result!.Result.Organisation);
+            Assert.AreEqual(status, result!.Result.Status);
         }
     }
 }

--- a/src/SFA.DAS.AANHub.Application.UnitTests/Partners/Queries/GetPartnerMemberResultTest.cs
+++ b/src/SFA.DAS.AANHub.Application.UnitTests/Partners/Queries/GetPartnerMemberResultTest.cs
@@ -17,7 +17,7 @@ namespace SFA.DAS.AANHub.Application.UnitTests.Partners.Queries
             Assert.AreEqual(partner.MemberId, response!.MemberId);
             Assert.AreEqual(partner.Organisation, response.Organisation);
             Assert.AreEqual(partner.Email, response.Email);
-
+            Assert.AreEqual(partner.Member.Status, response.Status);
         }
 
         [Test, AutoMoqData]

--- a/src/SFA.DAS.AANHub.Application/Admins/Queries/GetAdminMemberResult.cs
+++ b/src/SFA.DAS.AANHub.Application/Admins/Queries/GetAdminMemberResult.cs
@@ -9,6 +9,7 @@ namespace SFA.DAS.AANHub.Application.Admins.Queries
         public Guid MemberId { get; set; }
         public string Email { get; set; } = null!;
         public string Name { get; set; } = null!;
+        public string Status { get; set; } = null!;
 
         public static implicit operator GetAdminMemberResult?(Admin? admin)
         {
@@ -19,7 +20,8 @@ namespace SFA.DAS.AANHub.Application.Admins.Queries
             {
                 Email = admin.Email,
                 Name = admin.Name,
-                MemberId = admin.MemberId
+                MemberId = admin.MemberId,
+                Status = admin.Member.Status!
             };
         }
     }

--- a/src/SFA.DAS.AANHub.Application/Apprentices/Queries/GetApprenticeMemberResult.cs
+++ b/src/SFA.DAS.AANHub.Application/Apprentices/Queries/GetApprenticeMemberResult.cs
@@ -5,8 +5,10 @@ namespace SFA.DAS.AANHub.Application.Apprentices.Queries
     public class GetApprenticeMemberResult
     {
         public Guid MemberId { get; set; }
-        public string? Email { get; set; }
-        public string? Name { get; set; }
+        public string Email { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string Status { get; set; } = null!;
+
         public static implicit operator GetApprenticeMemberResult?(Apprentice apprentice)
         {
             if (apprentice == null)
@@ -17,6 +19,7 @@ namespace SFA.DAS.AANHub.Application.Apprentices.Queries
                 Email = apprentice.Email,
                 Name = apprentice.Name,
                 MemberId = apprentice.MemberId,
+                Status = apprentice.Member.Status!
             };
         }
     }

--- a/src/SFA.DAS.AANHub.Application/Employers/Queries/GetEmployerMemberResult.cs
+++ b/src/SFA.DAS.AANHub.Application/Employers/Queries/GetEmployerMemberResult.cs
@@ -8,6 +8,7 @@ namespace SFA.DAS.AANHub.Application.Employers.Queries
         public string Email { get; set; } = null!;
         public string Name { get; set; } = null!;
         public string Organisation { get; set; } = null!;
+        public string Status { get; set; } = null!;
 
         public static implicit operator GetEmployerMemberResult?(Employer? employer)
         {
@@ -19,7 +20,8 @@ namespace SFA.DAS.AANHub.Application.Employers.Queries
                 Email = employer.Email,
                 Name = employer.Name,
                 Organisation = employer.Organisation,
-                MemberId = employer.MemberId
+                MemberId = employer.MemberId,
+                Status = employer.Member.Status!
             };
         }
     }

--- a/src/SFA.DAS.AANHub.Application/Partners/Queries/GetPartnerMemberResult.cs
+++ b/src/SFA.DAS.AANHub.Application/Partners/Queries/GetPartnerMemberResult.cs
@@ -8,6 +8,7 @@ namespace SFA.DAS.AANHub.Application.Partners.Queries
         public string Email { get; set; } = null!;
         public string Name { get; set; } = null!;
         public string Organisation { get; set; } = null!;
+        public string Status { get; set; } = null!;
 
         public static implicit operator GetPartnerMemberResult?(Partner? partner)
         {
@@ -20,6 +21,7 @@ namespace SFA.DAS.AANHub.Application.Partners.Queries
                 Organisation = partner.Organisation,
                 Name = partner.Name,
                 MemberId = partner.MemberId,
+                Status = partner.Member.Status!
             };
         }
     }

--- a/src/SFA.DAS.AANHub.Data/Repositories/AdminsReadRepository.cs
+++ b/src/SFA.DAS.AANHub.Data/Repositories/AdminsReadRepository.cs
@@ -14,7 +14,7 @@ namespace SFA.DAS.AANHub.Data.Repositories
 
         public async Task<Admin?> GetAdminByUserName(string userName) => await _aanDataContext
             .Admins
-            .AsNoTracking().Where(a => a.UserName == userName)
+            .AsNoTracking().Where(a => a.UserName == userName).Include(x => x.Member)
             .SingleOrDefaultAsync();
     }
 }

--- a/src/SFA.DAS.AANHub.Data/Repositories/ApprenticesReadRepository.cs
+++ b/src/SFA.DAS.AANHub.Data/Repositories/ApprenticesReadRepository.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore;
 using SFA.DAS.AANHub.Domain.Entities;
 using SFA.DAS.AANHub.Domain.Interfaces.Repositories;
-using System.Diagnostics.CodeAnalysis;
 
 namespace SFA.DAS.AANHub.Data.Repositories
 {
@@ -14,7 +14,7 @@ namespace SFA.DAS.AANHub.Data.Repositories
 
         public async Task<Apprentice?> GetApprentice(long apprenticeId) => await _aanDataContext
                 .Apprentices
-                .AsNoTracking().Where(a => a.ApprenticeId == apprenticeId)
+                .AsNoTracking().Where(a => a.ApprenticeId == apprenticeId).Include(x => x.Member)
                 .SingleOrDefaultAsync();
     }
 }

--- a/src/SFA.DAS.AANHub.Data/Repositories/EmployersReadRepository.cs
+++ b/src/SFA.DAS.AANHub.Data/Repositories/EmployersReadRepository.cs
@@ -15,7 +15,7 @@ namespace SFA.DAS.AANHub.Data.Repositories
         public async Task<Employer?> GetEmployerByUserRef(Guid userRef) => await _aanDataContext
             .Employers
             .AsNoTracking()
-            .Where(m => m.UserRef == userRef)
+            .Where(m => m.UserRef == userRef).Include(x => x.Member)
             .SingleOrDefaultAsync();
     }
 }

--- a/src/SFA.DAS.AANHub.Data/Repositories/PartnersReadRepository.cs
+++ b/src/SFA.DAS.AANHub.Data/Repositories/PartnersReadRepository.cs
@@ -14,7 +14,7 @@ namespace SFA.DAS.AANHub.Data.Repositories
 
         public async Task<Partner?> GetPartnerByUserName(string userName) => await _aanDataContext
             .Partners
-            .AsNoTracking().Where(a => a.UserName == userName)
+            .AsNoTracking().Where(a => a.UserName == userName).Include(x => x.Member)
             .SingleOrDefaultAsync();
     }
 }

--- a/src/SFA.DAS.AANHub.Database/Tables/Apprentice.sql
+++ b/src/SFA.DAS.AANHub.Database/Tables/Apprentice.sql
@@ -2,8 +2,8 @@
 (
 	[MemberId] UNIQUEIDENTIFIER NOT NULL PRIMARY KEY, 
     [ApprenticeId] BIGINT NOT NULL, 
-    [Email] NVARCHAR(256) NULL, 
-    [Name] NVARCHAR(200) NULL, 
+    [Email] NVARCHAR(256) NOT NULL, 
+    [Name] NVARCHAR(200) NOT NULL, 
     [LastUpdated] DATETIME NULL
     CONSTRAINT [FK_Apprentice_Member] FOREIGN KEY ([MemberId]) REFERENCES [Member]([Id])
 )

--- a/src/SFA.DAS.AANHub.Domain/Entities/Admin.cs
+++ b/src/SFA.DAS.AANHub.Domain/Entities/Admin.cs
@@ -7,5 +7,6 @@
         public string Name { get; set; } = null!;
         public string UserName { get; set; } = null!;
         public DateTime? LastUpdated { get; set; }
+        public Member Member { get; set; } = null!;
     }
 }

--- a/src/SFA.DAS.AANHub.Domain/Entities/Apprentice.cs
+++ b/src/SFA.DAS.AANHub.Domain/Entities/Apprentice.cs
@@ -4,8 +4,9 @@
     {
         public Guid MemberId { get; set; }
         public long ApprenticeId { get; set; }
-        public string? Email { get; set; }
-        public string? Name { get; set; }
+        public string Email { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
         public DateTime? LastUpdated { get; set; }
+        public Member Member { get; set; } = null!;
     }
 }

--- a/src/SFA.DAS.AANHub.Domain/Entities/Employer.cs
+++ b/src/SFA.DAS.AANHub.Domain/Entities/Employer.cs
@@ -9,5 +9,6 @@
         public string Name { get; set; } = null!;
         public string Organisation { get; set; } = null!;
         public DateTime? LastUpdated { get; set; }
+        public Member Member { get; set; } = null!;
     }
 }

--- a/src/SFA.DAS.AANHub.Domain/Entities/Partner.cs
+++ b/src/SFA.DAS.AANHub.Domain/Entities/Partner.cs
@@ -8,5 +8,6 @@
         public string UserName { get; set; } = null!;
         public string Organisation { get; set; } = null!;
         public DateTime? LastUpdated { get; set; }
+        public Member Member { get; set; } = null!;
     }
 }


### PR DESCRIPTION
Added status field in employers, partners admins & apprentices. Written respected testcases. Made Name and Email columns to be non-nullable for entities in all the tables where applicable