### PR TITLE
FAI-958 AAN Hub API Condition to check if the Member already exist before Creation

### DIFF
--- a/src/SFA.DAS.AANHub.Application/Admins/Commands/CreateAdminMember/CreateAdminMemberCommandHandler.cs
+++ b/src/SFA.DAS.AANHub.Application/Admins/Commands/CreateAdminMember/CreateAdminMemberCommandHandler.cs
@@ -14,19 +14,28 @@ public class CreateAdminMemberCommandHandler : IRequestHandler<CreateAdminMember
     private readonly IAanDataContext _aanDataContext;
     private readonly IAuditWriteRepository _auditWriteRepository;
     private readonly IMembersWriteRepository _membersWriteRepository;
+    private readonly IMembersReadRepository _membersReadRepository;
 
     public CreateAdminMemberCommandHandler(IMembersWriteRepository membersWriteRepository,
-        IAanDataContext aanDataContext, IAuditWriteRepository auditWriteRepository)
+        IAanDataContext aanDataContext, IAuditWriteRepository auditWriteRepository,
+        IMembersReadRepository membersReadRepository)
     {
         _membersWriteRepository = membersWriteRepository;
         _aanDataContext = aanDataContext;
         _auditWriteRepository = auditWriteRepository;
+        _membersReadRepository = membersReadRepository;
     }
 
     public async Task<ValidatedResponse<CreateMemberCommandResponse>> Handle(CreateAdminMemberCommand command,
         CancellationToken cancellationToken)
     {
         Member member = command;
+
+        //condition to check if the member already exist in the repo.
+        var user = await _membersReadRepository.GetMemberByEmail(member.Email);
+
+        if (user != null)
+            return new ValidatedResponse<CreateMemberCommandResponse>(new CreateMemberCommandResponse(user.Id));
 
         _membersWriteRepository.Create(member);
 


### PR DESCRIPTION
Commit: Condition to check the Member already exist before creating the duplicate Member in the repo.

Story: https://skillsfundingagency.atlassian.net/browse/FAI-958

`Microsoft.Data.SqlClient.SqlException (0x80131904): Cannot insert duplicate key row in object 'dbo.Member' with unique index 'IX_Member_Email'. The duplicate key value is (xxxxx@education.gov.uk).`

